### PR TITLE
Refactor trip data to cleanly pull destination data upon instantiation

### DIFF
--- a/src/trip.js
+++ b/src/trip.js
@@ -4,6 +4,8 @@ class Trip {
     this.userID = data.userID,
     this.destinationID = data.destinationID,
     this.destinationName = undefined,
+    this.image = undefined,
+    this.imageAlt = undefined,
     this.travelers = data.travelers,
     this.date = data.date,
     this.duration = data.duration,
@@ -30,6 +32,19 @@ class Trip {
     this.totalCost = tripCost + agentFee
 }
 
+  grabDestinationImages(array){
+    const destinationResult = array.find((item) => {
+      return item.id === this.destinationID
+    })
+    this.imageAlt = destinationResult.alt;
+    this.image = destinationResult.image;
+  }
+
+  siphonDestinationData(array) {
+      this.convertDestinationID(array)
+      this.calculateTotalCost(array)
+      this.grabDestinationImages(array)
+  }
 
 }
 

--- a/src/trips-repo.js
+++ b/src/trips-repo.js
@@ -19,8 +19,7 @@ class TripsRepository {
   createTrips(){
     const createdTrips = this.rawData.map((data) => {
       let newTrip = new Trip(data)
-      newTrip.convertDestinationID(this.destinations)
-      newTrip.calculateTotalCost(this.destinations)
+      newTrip.siphonDestinationData(this.destinations)
       return newTrip
     })
     this.trips = createdTrips


### PR DESCRIPTION
1. What (if any) features are you implementing?
- none

2. What (if anything) did you refactor?
- refactored trip methods so that there is a single helper method to pull all relevant data from the destination API to it's relevant trip class.
- now there is a single helper method called siphoneDestinationData which calls the following methods:
- convertDestinationID - looks in the destinations array and tells the trip the name of the destination location based on the current destinationID
- calculateTotalCost - this was built in my previous commit, this adds a totalCost property to each given trip and calculates it based off data from the destination API and how many travelers are associated with a trip
- grabDestinationImages - as it sounds, looks for a matching object in the destinations API and assigns the image and alt text properties from the destinations object to the relevant trip. 

3. Were there any issues that arose?
- just a casual error that broke everything for a moment, as always, was a typo or forgotten curly brace that brought the whole system down 

4. Any other comments, questions, or concerns?
- None at this time. 
